### PR TITLE
Hotfix for breaking change in fastcore/fastai

### DIFF
--- a/cinnamon-synthetization/requirements.txt
+++ b/cinnamon-synthetization/requirements.txt
@@ -16,3 +16,6 @@ requests==2.32.3
 numpy==1.26.4
 joblib==1.4.2
 synthcity==0.2.11
+# Hotfix for https://github.com/timeseriesAI/tsai/issues/939
+fastcore==1.7.29
+fastai==2.7.19


### PR DESCRIPTION
## Notes

A breaking change in fastcore/fastai broke tsai which is required by synthcity.
See: https://github.com/timeseriesAI/tsai/issues/939

## Changes
Internal
- Hotfix for breaking change in fastcore/fastai