### PR TITLE
Removed CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,0 @@
-# Learn about CODEOWNERS file format:
-#  https://help.github.com/en/articles/about-code-owners
-#
-
-# These owners will be the default owners for everything in the repo.
-* @ywarnecke @storckmi @prasser @DanielPreciado-Marquez @karen-otte @JosGruT @martinkuhn94 @AnnaPasquier


### PR DESCRIPTION
## Notes

I changed the security settings of the repository analog to cinnamon-docs. The CODEOWNERS is not required anymore.

## Changes

Removed:
- Removed CODEOWNERS