### PR TITLE
Fixed unused flag for ignoring max number of parallel processes (#258)

### DIFF
--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/service/ExternalServerInstanceService.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/service/ExternalServerInstanceService.java
@@ -53,7 +53,7 @@ public class ExternalServerInstanceService {
 
 		for (final Pair<ExternalServerInstance, Long> instance : instances) {
 			// Check if capacities are available for this instance
-			if (instance.getFirst().getMaxParallelProcess() >= 0) {
+			if (!ignoreMaxParallelProcess && instance.getFirst().getMaxParallelProcess() >= 0) {
 				if (instance.getSecond() >= instance.getFirst().getMaxParallelProcess()) {
 					continue;
 				}


### PR DESCRIPTION
## Changes

Fixes:
- Fixed unused flag for ignoring max number of parallel processes (#258)

Closes #258