### PR TITLE
Add abstraction for external host (#265)

### DIFF
--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/health/ExternalServerHealthContributor.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/health/ExternalServerHealthContributor.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * @author Daniel Preciado-Marquez
  */
 @Component
-@DependsOn({"kiAimConfigurationPostProcessor"})
+@DependsOn({"cinnamonConfigurationPostProcessor"})
 public class ExternalServerHealthContributor implements CompositeHealthContributor {
 
 	private final Map<String, HealthContributor> healthContributors = new LinkedHashMap<>();

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/helper/CinnamonConfigurationPostProcessor.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/helper/CinnamonConfigurationPostProcessor.java
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component;
  * @author Daniel Preciado-Marquez
  */
 @Component
-public class KiAimConfigurationPostProcessor {
+public class CinnamonConfigurationPostProcessor {
 
 	private final CinnamonConfiguration config;
 
-	public KiAimConfigurationPostProcessor(final CinnamonConfiguration config) {
+	public CinnamonConfigurationPostProcessor(final CinnamonConfiguration config) {
 		this.config = config;
 	}
 

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/helper/KiAimConfigurationPostProcessor.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/helper/KiAimConfigurationPostProcessor.java
@@ -47,6 +47,11 @@ public class KiAimConfigurationPostProcessor {
 		for (final var entry : config.getStages().entrySet()) {
 			entry.getValue().setStageName(entry.getKey());
 		}
+
+		// Set names of hosts
+		for (final var entry : config.getExternalHost().entrySet()) {
+			entry.getValue().setName(entry.getKey());
+		}
 	}
 
 	private void link() throws InternalApplicationConfigurationException {
@@ -54,6 +59,11 @@ public class KiAimConfigurationPostProcessor {
 		for (final var server : config.getExternalServer().values()) {
 			for (final var instance : server.getInstances().values()) {
 				instance.setServer(server);
+
+				// Link hosts and instances
+				final var host = config.getExternalHost().get(instance.getHostName());
+				host.getInstances().add(instance);
+				instance.setHost(host);
 			}
 		}
 

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/CinnamonConfiguration.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/CinnamonConfiguration.java
@@ -30,6 +30,11 @@ public class CinnamonConfiguration {
 
 	private Map<String, ExternalConfiguration> externalConfiguration = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
+	/**
+	 * Hosts that are running external server instances.
+	 */
+	private Map<String, ExternalHost> externalHost = new HashMap<>();
+
 	private Map<String, ExternalServer> externalServer = new HashMap<>();
 
 	private Map<Integer, ExternalEndpoint> externalServerEndpoints = new HashMap<>();

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalHost.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalHost.java
@@ -10,10 +10,10 @@ import java.util.Set;
 public class ExternalHost {
 
 	/**
-	 * The maximum number of parallel processes by any module on the host.
+	 * Maximum number of processes that are allowed to run in parallel on the host.
 	 * Negative values allow an unlimited number of processes.
 	 * <p>
-	 * Default is -1.
+	 * The default is -1.
 	 */
 	private int maxParallelProcess = -1;
 

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalHost.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalHost.java
@@ -1,0 +1,39 @@
+package de.kiaim.cinnamon.platform.model.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter @Setter
+public class ExternalHost {
+
+	/**
+	 * The maximum number of parallel processes by any module on the host.
+	 * Negative values allow an unlimited number of processes.
+	 * <p>
+	 * Default is -1.
+	 */
+	private int maxParallelProcess = -1;
+
+	/**
+	 * URL of the host.
+	 */
+	private String url;
+
+	//=========================
+	//--- Automatically set ---
+	//=========================
+
+	/**
+	 * The name of the host defined in {@link CinnamonConfiguration#getExternalHost()}.
+	 */
+	private String name;
+
+	/**
+	 * Instances using this host.
+	 * Mapped by {@link ExternalServerInstance#getHost()}
+	 */
+	private Set<ExternalServerInstance> instances = new HashSet<>();
+}

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServer.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServer.java
@@ -1,6 +1,6 @@
 package de.kiaim.cinnamon.platform.model.configuration;
 
-import de.kiaim.cinnamon.platform.helper.KiAimConfigurationPostProcessor;
+import de.kiaim.cinnamon.platform.helper.CinnamonConfigurationPostProcessor;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.lang.Nullable;
@@ -59,7 +59,7 @@ public class ExternalServer {
 	//=========================
 
 	/**
-	 * Name of the server. Is automatically set at {@link KiAimConfigurationPostProcessor#init()}.
+	 * Name of the server. Is automatically set at {@link CinnamonConfigurationPostProcessor#init()}.
 	 */
 	private String name;
 

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServer.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServer.java
@@ -50,6 +50,13 @@ public class ExternalServer {
 	private Integer minUp = null;
 
 	/**
+	 * Default host port used for all instances.
+	 * <p>
+	 * The default value is 80.
+	 */
+	private int instanceHostPort = 80;
+
+	/**
 	 * List of instances for the external server.
 	 */
 	private Map<String, ExternalServerInstance> instances = new HashMap<>();

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServerInstance.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServerInstance.java
@@ -44,8 +44,11 @@ public class ExternalServerInstance {
 
 	/**
 	 * Port of the instance on the host.
+	 * If the value is null, the value of {@link ExternalServer#getInstanceHostPort()} will be used.
+	 * <p>
 	 */
-	private int port;
+	@Nullable
+	private Integer port = null;
 
 	//=========================
 	//--- Automatically set ---
@@ -113,12 +116,22 @@ public class ExternalServerInstance {
 	}
 
 	/**
+	 * Returns the port of the instance on the host.
+	 * If the port of the instance is null, the default value specified in {@link ExternalServer#getInstanceHostPort()} is used.
+	 *
+	 * @return The port of the instance on the host.
+	 */
+	public int getPort() {
+		return port == null ? server.getInstanceHostPort() : port;
+	}
+
+	/**
 	 * URL of this instance.
 	 *
 	 * @return The URL.
 	 */
 	public String getUrl() {
-		return host.getUrl() + ":" + port;
+		return host.getUrl() + ":" + getPort();
 	}
 
 }

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServerInstance.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/model/configuration/ExternalServerInstance.java
@@ -32,15 +32,20 @@ public class ExternalServerInstance {
 	private Integer healthTimeout = null;
 
 	/**
+	 * Name of the host this instances runs on.
+	 */
+	private String hostName;
+
+	/**
 	 * See {@link #getMaxParallelProcess()}.
 	 */
 	@Nullable
 	private Integer maxParallelProcess = null;
 
 	/**
-	 * URL of the instance.
+	 * Port of the instance on the host.
 	 */
-	private String url;
+	private int port;
 
 	//=========================
 	//--- Automatically set ---
@@ -51,6 +56,12 @@ public class ExternalServerInstance {
 	 * Mapped by {@link ExternalServer#getInstances()}
 	 */
 	private ExternalServer server;
+
+	/**
+	 * The host this instance is running on.
+	 * Mapped by {@link ExternalHost#getInstances()}
+	 */
+	private ExternalHost host;
 
 	/**
 	 * The name of the instance defined in {@link ExternalServer#getInstances()}.
@@ -99,6 +110,15 @@ public class ExternalServerInstance {
 	 */
 	public String getId() {
 		return server.getName() + ID_SEPARATOR + name;
+	}
+
+	/**
+	 * URL of this instance.
+	 *
+	 * @return The URL.
+	 */
+	public String getUrl() {
+		return host.getUrl() + ":" + port;
 	}
 
 }

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/repository/BackgroundProcessRepository.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/repository/BackgroundProcessRepository.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 public interface BackgroundProcessRepository extends CrudRepository<BackgroundProcessEntity, Long> {
 	Optional<BackgroundProcessEntity> findByUuid(UUID uuid);
 
+	long countByServerInstance(String instance);
+
 	long countByServerInstanceIn(Collection<String> instance);
 
 	List<BackgroundProcessEntity> findByEndpointInAndExternalProcessStatusOrderByScheduledTimeAsc(

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/repository/BackgroundProcessRepository.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/repository/BackgroundProcessRepository.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public interface BackgroundProcessRepository extends CrudRepository<BackgroundProcessEntity, Long> {
 	Optional<BackgroundProcessEntity> findByUuid(UUID uuid);
 
-	long countByServerInstance(String serverInstance);
+	long countByServerInstanceIn(Collection<String> instance);
 
 	List<BackgroundProcessEntity> findByEndpointInAndExternalProcessStatusOrderByScheduledTimeAsc(
 			Collection<Integer> endpoints,

--- a/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/service/ExternalServerInstanceService.java
+++ b/cinnamon-platform/src/main/java/de/kiaim/cinnamon/platform/service/ExternalServerInstanceService.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Service for everything regarding extern server instances.
@@ -42,9 +43,13 @@ public class ExternalServerInstanceService {
 
 		final List<Pair<ExternalServerInstance, Long>> instances = new ArrayList<>(externalServer.getInstances().size());
 
-		// Get the number of running processes per instance
+		// Get the number of processes running on the host of each instance
 		for (final ExternalServerInstance instance : externalServer.getInstances().values()) {
-			var count = backgroundProcessRepository.countByServerInstance(instance.getId());
+			final Set<String> hostInstances = instance.getHost().getInstances().stream()
+			                                          .map(ExternalServerInstance::getId)
+			                                          .collect(Collectors.toSet());
+
+			var count = backgroundProcessRepository.countByServerInstanceIn(hostInstances);
 			instances.add(Pair.of(instance, count));
 		}
 

--- a/cinnamon-platform/src/main/resources/application.properties
+++ b/cinnamon-platform/src/main/resources/application.properties
@@ -38,24 +38,30 @@ cinnamon.steps.risk_evaluation.step-type=evaluation
 cinnamon.steps.base_evaluation.external-server-endpoint-index=5
 cinnamon.steps.base_evaluation.step-type=evaluation
 
+cinnamon.external-host.0.url=http://localhost
+
 cinnamon.external-server.anonymization-server.callback-host=localhost
 cinnamon.external-server.anonymization-server.health-endpoint=/actuator/health
-cinnamon.external-server.anonymization-server.instances.0.url=http://localhost:8081
+cinnamon.external-server.anonymization-server.instances.0.host-name=0
+cinnamon.external-server.anonymization-server.instances.0.port=8081
 cinnamon.external-server.anonymization-server.max-parallel-process=1
 
 cinnamon.external-server.synthetization-server.callback-host=localhost
 cinnamon.external-server.synthetization-server.health-endpoint=/actuator/health
-cinnamon.external-server.synthetization-server.instances.0.url=http://localhost:5000
+cinnamon.external-server.synthetization-server.instances.0.host-name=0
+cinnamon.external-server.synthetization-server.instances.0.port=5000
 cinnamon.external-server.synthetization-server.max-parallel-process=1
 
 cinnamon.external-server.technical-evaluation-server.callback-host=localhost
 cinnamon.external-server.technical-evaluation-server.health-endpoint=/actuator/health
-cinnamon.external-server.technical-evaluation-server.instances.0.url=http://localhost:5010
+cinnamon.external-server.technical-evaluation-server.instances.0.host-name=0
+cinnamon.external-server.technical-evaluation-server.instances.0.port=5010
 cinnamon.external-server.technical-evaluation-server.max-parallel-process=1
 
 cinnamon.external-server.risk-assessment-server.callback-host=localhost
 cinnamon.external-server.risk-assessment-server.health-endpoint=/actuator/health
-cinnamon.external-server.risk-assessment-server.instances.0.url=http://localhost:8000
+cinnamon.external-server.risk-assessment-server.instances.0.host-name=0
+cinnamon.external-server.risk-assessment-server.instances.0.port=8000
 cinnamon.external-server.risk-assessment-server.max-parallel-process=1
 
 cinnamon.external-configuration.anonymization.algorithm-endpoint=/api/anonymization/algorithms

--- a/cinnamon-platform/src/main/resources/application.properties
+++ b/cinnamon-platform/src/main/resources/application.properties
@@ -42,26 +42,26 @@ cinnamon.external-host.0.url=http://localhost
 
 cinnamon.external-server.anonymization-server.callback-host=localhost
 cinnamon.external-server.anonymization-server.health-endpoint=/actuator/health
+cinnamon.external-server.anonymization-server.instance-host-port=8081
 cinnamon.external-server.anonymization-server.instances.0.host-name=0
-cinnamon.external-server.anonymization-server.instances.0.port=8081
 cinnamon.external-server.anonymization-server.max-parallel-process=1
 
 cinnamon.external-server.synthetization-server.callback-host=localhost
 cinnamon.external-server.synthetization-server.health-endpoint=/actuator/health
+cinnamon.external-server.synthetization-server.instance-host-port=5000
 cinnamon.external-server.synthetization-server.instances.0.host-name=0
-cinnamon.external-server.synthetization-server.instances.0.port=5000
 cinnamon.external-server.synthetization-server.max-parallel-process=1
 
 cinnamon.external-server.technical-evaluation-server.callback-host=localhost
 cinnamon.external-server.technical-evaluation-server.health-endpoint=/actuator/health
+cinnamon.external-server.technical-evaluation-server.instance-host-port=5010
 cinnamon.external-server.technical-evaluation-server.instances.0.host-name=0
-cinnamon.external-server.technical-evaluation-server.instances.0.port=5010
 cinnamon.external-server.technical-evaluation-server.max-parallel-process=1
 
 cinnamon.external-server.risk-assessment-server.callback-host=localhost
 cinnamon.external-server.risk-assessment-server.health-endpoint=/actuator/health
+cinnamon.external-server.risk-assessment-server.instance-host-port=8000
 cinnamon.external-server.risk-assessment-server.instances.0.host-name=0
-cinnamon.external-server.risk-assessment-server.instances.0.port=8000
 cinnamon.external-server.risk-assessment-server.max-parallel-process=1
 
 cinnamon.external-configuration.anonymization.algorithm-endpoint=/api/anonymization/algorithms

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/helper/CinnamonConfigurationPostProcessorTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/helper/CinnamonConfigurationPostProcessorTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class KiAimConfigurationPostProcessorTest extends ContextRequiredTest {
+public class CinnamonConfigurationPostProcessorTest extends ContextRequiredTest {
 
 	@Autowired
 	private CinnamonConfiguration config;

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.util.TestSocketUtils;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,7 +23,6 @@ import static org.mockito.Mockito.when;
 
 public class ExternalServerInstanceServiceTest {
 
-	ExternalHost host;
 	ExternalServer es;
 	ExternalServerInstance esi1;
 	ExternalServerInstance esi2;
@@ -30,10 +30,6 @@ public class ExternalServerInstanceServiceTest {
 
 	@BeforeEach
 	public void setup() {
-		host = new ExternalHost();
-		host.setName("localhost");
-		host.setUrl("http://localhost");
-
 		es = createConfig();
 		esi1 = es.getInstances().get("esi1");
 		esi2 = es.getInstances().get("esi2");
@@ -142,15 +138,17 @@ public class ExternalServerInstanceServiceTest {
 		esi.setServer(es);
 		es.getInstances().put(esi.getName(), esi);
 
+		var host = new ExternalHost();
+		host.setUrl("http://localhost");
 		esi.setHost(host);
 		host.getInstances().add(esi);
 	}
 
 	private ExternalServerInstanceService createService(final long count1, final long count2, final long count3) {
 		BackgroundProcessRepository repo = mock(BackgroundProcessRepository.class);
-		when(repo.countByServerInstance(eq(esi1.getId()))).thenReturn(count1);
-		when(repo.countByServerInstance(eq(esi2.getId()))).thenReturn(count2);
-		when(repo.countByServerInstance(eq(esi3.getId()))).thenReturn(count3);
+		when(repo.countByServerInstanceIn(eq(Set.of(esi1.getId())))).thenReturn(count1);
+		when(repo.countByServerInstanceIn(eq(Set.of(esi2.getId())))).thenReturn(count2);
+		when(repo.countByServerInstanceIn(eq(Set.of(esi3.getId())))).thenReturn(count3);
 		return new ExternalServerInstanceService(repo);
 	}
 

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
@@ -171,9 +171,7 @@ public class ExternalServerInstanceServiceTest {
 			final int mockBackEndPort = TestSocketUtils.findAvailableTcpPort();
 			mockBackEnd.start(mockBackEndPort);
 
-			esi1.setPort(mockBackEndPort);
-			esi2.setPort(mockBackEndPort);
-			esi3.setPort(mockBackEndPort);
+			es.setInstanceHostPort(mockBackEndPort);
 
 			runnable.accept(mockBackEnd);
 		} catch (IOException e) {

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
@@ -1,5 +1,6 @@
 package de.kiaim.cinnamon.test.platform.service;
 
+import de.kiaim.cinnamon.platform.model.configuration.ExternalHost;
 import de.kiaim.cinnamon.platform.model.configuration.ExternalServer;
 import de.kiaim.cinnamon.platform.model.configuration.ExternalServerInstance;
 import de.kiaim.cinnamon.platform.repository.BackgroundProcessRepository;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 public class ExternalServerInstanceServiceTest {
 
+	ExternalHost host;
 	ExternalServer es;
 	ExternalServerInstance esi1;
 	ExternalServerInstance esi2;
@@ -28,6 +30,10 @@ public class ExternalServerInstanceServiceTest {
 
 	@BeforeEach
 	public void setup() {
+		host = new ExternalHost();
+		host.setName("localhost");
+		host.setUrl("http://localhost");
+
 		es = createConfig();
 		esi1 = es.getInstances().get("esi1");
 		esi2 = es.getInstances().get("esi2");
@@ -135,6 +141,9 @@ public class ExternalServerInstanceServiceTest {
 
 		esi.setServer(es);
 		es.getInstances().put(esi.getName(), esi);
+
+		esi.setHost(host);
+		host.getInstances().add(esi);
 	}
 
 	private ExternalServerInstanceService createService(final long count1, final long count2, final long count3) {
@@ -164,9 +173,9 @@ public class ExternalServerInstanceServiceTest {
 			final int mockBackEndPort = TestSocketUtils.findAvailableTcpPort();
 			mockBackEnd.start(mockBackEndPort);
 
-			esi1.setUrl(String.format("http://localhost:%s", mockBackEndPort));
-			esi2.setUrl(String.format("http://localhost:%s", mockBackEndPort));
-			esi3.setUrl(String.format("http://localhost:%s", mockBackEndPort));
+			esi1.setPort(mockBackEndPort);
+			esi2.setPort(mockBackEndPort);
+			esi3.setPort(mockBackEndPort);
 
 			runnable.accept(mockBackEnd);
 		} catch (IOException e) {

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ExternalServerInstanceServiceTest.java
@@ -146,6 +146,11 @@ public class ExternalServerInstanceServiceTest {
 
 	private ExternalServerInstanceService createService(final long count1, final long count2, final long count3) {
 		BackgroundProcessRepository repo = mock(BackgroundProcessRepository.class);
+
+		when(repo.countByServerInstance(eq(esi1.getId()))).thenReturn(count1);
+		when(repo.countByServerInstance(eq(esi2.getId()))).thenReturn(count2);
+		when(repo.countByServerInstance(eq(esi3.getId()))).thenReturn(count3);
+
 		when(repo.countByServerInstanceIn(eq(Set.of(esi1.getId())))).thenReturn(count1);
 		when(repo.countByServerInstanceIn(eq(Set.of(esi2.getId())))).thenReturn(count2);
 		when(repo.countByServerInstanceIn(eq(Set.of(esi3.getId())))).thenReturn(count3);

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ProcessServiceTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ProcessServiceTest.java
@@ -53,16 +53,9 @@ public class ProcessServiceTest extends ContextRequiredTest {
 		ExternalServerInstanceService externalServerInstanceService = mock(ExternalServerInstanceService.class);
 		ProjectRepository projectRepository = mock(ProjectRepository.class);
 
-		var url = cinnamonConfiguration.getExternalServer()
-		                               .get("anonymization-server")
-		                               .getInstances()
-		                               .get("0")
-		                               .getUrl();
 		cinnamonConfiguration.getExternalServer()
 		                     .get("anonymization-server")
-		                     .getInstances()
-		                     .get("0")
-		                     .setPort(mockBackEnd.getPort());
+		                     .setInstanceHostPort(mockBackEnd.getPort());
 		this.processService = new ProcessService(serializationConfig, port, cinnamonConfiguration,
 		                                         backgroundProcessRepository, projectRepository, csvProcessor,
 		                                         databaseService, dataProcessorService, dataSetService,

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ProcessServiceTest.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/platform/service/ProcessServiceTest.java
@@ -62,7 +62,7 @@ public class ProcessServiceTest extends ContextRequiredTest {
 		                     .get("anonymization-server")
 		                     .getInstances()
 		                     .get("0")
-		                     .setUrl(url.substring(0, url.lastIndexOf(":") + 1) + mockBackEnd.getPort());
+		                     .setPort(mockBackEnd.getPort());
 		this.processService = new ProcessService(serializationConfig, port, cinnamonConfiguration,
 		                                         backgroundProcessRepository, projectRepository, csvProcessor,
 		                                         databaseService, dataProcessorService, dataSetService,

--- a/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/util/MockWebServerExtension.java
+++ b/cinnamon-test/src/test/java/de/kiaim/cinnamon/test/util/MockWebServerExtension.java
@@ -23,12 +23,12 @@ public class MockWebServerExtension implements BeforeAllCallback, BeforeEachCall
 
 	@Override
 	public void beforeAll(final ExtensionContext context) {
-		System.setProperty("cinnamon.external-server.technical-evaluation-server.instances.0.url",
-		                   String.format("http://localhost:%s", mockBackEndPort));
-		System.setProperty("cinnamon.external-server.synthetization-server.instances.0.url",
-		                   String.format("http://localhost:%s", mockBackEndPort));
-		System.setProperty("cinnamon.external-server.anonymization-server.instances.0.url",
-		                   String.format("http://localhost:%s", mockBackEndPort));
+		System.setProperty("cinnamon.external-server.technical-evaluation-server.instances.0.port",
+		                   String.valueOf(mockBackEndPort));
+		System.setProperty("cinnamon.external-server.synthetization-server.instances.0.port",
+		                   String.valueOf(mockBackEndPort));
+		System.setProperty("cinnamon.external-server.anonymization-server.instances.0.port",
+		                   String.valueOf(mockBackEndPort));
 	}
 
 	@Override

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,18 +45,29 @@ services:
 
             CINNAMON_IS-DEMO-INSTANCE: ${IS_DEMO_INSTANCE:-false}
 
+            # Hosts
+            CINNAMON.EXTERNAL-HOST.anonymization-host.URL: http://cinnamon-anonymization
+            CINNAMON.EXTERNAL-HOST.synthetization-host.URL: http://cinnamon-synthetization
+            CINNAMON.EXTERNAL-HOST.technical-evaluation-host.URL: http://cinnamon-evaluation
+            CINNAMON.EXTERNAL-HOST.risk-assessment-host.URL: http://cinnamon-risk-assessment
+
             # Anonymization
             CINNAMON.EXTERNAL-SERVER.anonymization-server.CALLBACK-HOST: cinnamon-platform
-            CINNAMON.EXTERNAL-SERVER.anonymization-server.instances.0.URL: http://cinnamon-anonymization:8080
+            CINNAMON.EXTERNAL-SERVER.anonymization-server.INSTANCES.0.HOST-NAME: anonymization-host
+            CINNAMON.EXTERNAL-SERVER.anonymization-server.INSTANCES.0.PORT: 8080
             # Synthetization
             CINNAMON.EXTERNAL-SERVER.synthetization-server.CALLBACK-HOST: cinnamon-platform
-            CINNAMON.EXTERNAL-SERVER.synthetization-server.instances.0.URL: http://cinnamon-synthetization:5000
+            CINNAMON.EXTERNAL-SERVER.synthetization-server.INSTANCES.0.HOST-NAME: synthetization-host
+            CINNAMON.EXTERNAL-SERVER.synthetization-server.INSTANCES.0.PORT: 5000
             # Evaluation
             CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.CALLBACK-HOST: cinnamon-platform
-            CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.instances.0.URL: http://cinnamon-evaluation:5010
+            CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.INSTANCES.0.HOST-NAME: technical-evaluation-host
+            CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.INSTANCES.0.PORT: 5010
 
+            # Risk Assessment
             CINNAMON.EXTERNAL-SERVER.risk-assessment-server.CALLBACK-HOST: cinnamon-platform
-            CINNAMON.EXTERNAL-SERVER.risk-assessment-server.instances.0.URL: http://cinnamon-risk-assessment:8000
+            CINNAMON.EXTERNAL-SERVER.risk-assessment-server.INSTANCES.0.HOST-NAME: risk-assessment-host
+            CINNAMON.EXTERNAL-SERVER.risk-assessment-server.INSTANCES.0.PORT: 8000
         depends_on:
             - cinnamon-db
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,21 +53,17 @@ services:
 
             # Anonymization
             CINNAMON.EXTERNAL-SERVER.anonymization-server.CALLBACK-HOST: cinnamon-platform
+            CINNAMON.EXTERNAL-SERVER.anonymization-server.INSTANCE-HOST-PORT: 8080
             CINNAMON.EXTERNAL-SERVER.anonymization-server.INSTANCES.0.HOST-NAME: anonymization-host
-            CINNAMON.EXTERNAL-SERVER.anonymization-server.INSTANCES.0.PORT: 8080
             # Synthetization
             CINNAMON.EXTERNAL-SERVER.synthetization-server.CALLBACK-HOST: cinnamon-platform
             CINNAMON.EXTERNAL-SERVER.synthetization-server.INSTANCES.0.HOST-NAME: synthetization-host
-            CINNAMON.EXTERNAL-SERVER.synthetization-server.INSTANCES.0.PORT: 5000
             # Evaluation
             CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.CALLBACK-HOST: cinnamon-platform
             CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.INSTANCES.0.HOST-NAME: technical-evaluation-host
-            CINNAMON.EXTERNAL-SERVER.technical-evaluation-server.INSTANCES.0.PORT: 5010
-
             # Risk Assessment
             CINNAMON.EXTERNAL-SERVER.risk-assessment-server.CALLBACK-HOST: cinnamon-platform
             CINNAMON.EXTERNAL-SERVER.risk-assessment-server.INSTANCES.0.HOST-NAME: risk-assessment-host
-            CINNAMON.EXTERNAL-SERVER.risk-assessment-server.INSTANCES.0.PORT: 8000
         depends_on:
             - cinnamon-db
         healthcheck:


### PR DESCRIPTION
## Notes
Each physical server can now be model as an external host.
This is used when looking for a host with the least number of running processes.

The configuration on the demo server must be adapted.

## Changes
New Features:
- Added external hosts (#265)

Code Quality:
- Renamed KiAimConfigurationPostProcessor to CinnamonConfigurationPostProcessor

Closes #265

