### PR TITLE
Delete cached algorithm definitions when unlocking a step (#263)

### DIFF
--- a/cinnamon-platform/cinnamon-frontend/src/app/core/services/state-management.service.ts
+++ b/cinnamon-platform/cinnamon-frontend/src/app/core/services/state-management.service.ts
@@ -2,8 +2,12 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from '@angular/core';
 import { NavigationEnd, Router } from "@angular/router";
 import { ProcessStatus } from "@core/enums/process-status";
+import { AnonymizationService } from "@features/anonymization/services/anonymization.service";
 import { DataSetInfoService } from "@features/data-upload/services/data-set-info.service";
 import { FileService } from "@features/data-upload/services/file.service";
+import { RiskAssessmentService } from "@features/risk-assessment/services/risk-assessment.service";
+import { SynthetizationService } from "@features/synthetization/services/synthetization.service";
+import { TechnicalEvaluationService } from "@features/technical-evaluation/services/technical-evaluation.service";
 import { ExecutionStep, PipelineInformation } from "@shared/model/execution-step";
 import { Status } from "@shared/model/status";
 import { ConfigurationService } from "@shared/services/configuration.service";
@@ -41,13 +45,17 @@ export class StateManagementService {
     private _pipelineSubscription: Subscription | null = null;
 
     constructor(
+        private readonly anonymizationService: AnonymizationService,
         private readonly configurationService: ConfigurationService,
         protected readonly dataSetInfoService: DataSetInfoService,
         private readonly fileService: FileService,
         private readonly http: HttpClient,
+        private readonly riskAssessmentService: RiskAssessmentService,
         private readonly router: Router,
         private readonly userService: UserService,
         private readonly statusService: StatusService,
+        private readonly synthetizationService: SynthetizationService,
+        private readonly technicalEvaluationService: TechnicalEvaluationService,
     ) {
         if (this.userService.isAuthenticated()) {
             this.fetchCurrentStep();
@@ -285,6 +293,12 @@ export class StateManagementService {
                 this.configurationService.invalidateCache();
                 this.fileService.invalidateCache();
                 this.dataSetInfoService.invalidateCache();
+
+                // Delete cached algorithm definitions as they can contain injected parameters
+                this.anonymizationService.invalidateCachedAlgorithmDefinitions();
+                this.riskAssessmentService.invalidateCachedAlgorithmDefinitions();
+                this.synthetizationService.invalidateCachedAlgorithmDefinitions();
+                this.technicalEvaluationService.invalidateCachedAlgorithmDefinitions();
             }),
         );
     }

--- a/cinnamon-platform/cinnamon-frontend/src/app/shared/services/algorithm.service.ts
+++ b/cinnamon-platform/cinnamon-frontend/src/app/shared/services/algorithm.service.ts
@@ -2,7 +2,7 @@ import { Algorithm } from "../model/algorithm";
 import { AlgorithmDefinition } from "../model/algorithm-definition";
 import { HttpClient } from "@angular/common/http";
 import { catchError, map, Observable, of, tap } from "rxjs";
-import { parse, stringify } from "yaml";
+import { parse } from "yaml";
 import { plainToInstance } from "class-transformer";
 import { ConfigurationService } from "./configuration.service";
 import { ImportPipeData } from "../model/import-pipe-data";
@@ -152,6 +152,13 @@ export abstract class AlgorithmService {
         } else {
             return of(this._algorithms);
         }
+    }
+
+    /**
+     * Deleted cached configuration definitions.
+     */
+    public invalidateCachedAlgorithmDefinitions(): void {
+        this.algorithmDefinitions = {};
     }
 
     private loadAlgorithms(): Observable<Algorithm[]> {


### PR DESCRIPTION
## Changes

Fixes:
- Fixed parameters in cached algorithm definition not getting updated after unlocking the data import (#263)

Closes #263