### PR TITLE
Handle data type text

### DIFF
--- a/cinnamon-anonymization/src/main/java/de/kiaim/cinnamon/anonymization/helper/DataGeneration.java
+++ b/cinnamon-anonymization/src/main/java/de/kiaim/cinnamon/anonymization/helper/DataGeneration.java
@@ -24,6 +24,7 @@ public class DataGeneration {
             case DECIMAL -> new DecimalData((Float) value);
             case INTEGER -> new IntegerData((Integer) value);
             case STRING -> new StringData((String) value);
+            case TEXT -> new TextData((String) value);
             default -> throw new IllegalArgumentException("Unsupported data type: " + type);
         };
     }
@@ -47,6 +48,7 @@ public class DataGeneration {
                 case DECIMAL -> new DecimalData(null);
                 case BOOLEAN -> new BooleanData(null);
                 case STRING -> new StringData(null);
+                case TEXT -> new TextData(null);
                 default -> throw new IllegalArgumentException("Unsupported data type: " + type);
             };
         } else {
@@ -57,6 +59,7 @@ public class DataGeneration {
                 case BOOLEAN -> new BooleanData((Boolean) value);
                 case STRING -> new StringData(value.toString());
                 case DATE_TIME -> new DateTimeData((LocalDateTime) value);
+                case TEXT -> new TextData(value.toString());
                 default -> throw new IllegalArgumentException("Unsupported data type: " + type);
             };
         }

--- a/cinnamon-anonymization/src/main/java/de/kiaim/cinnamon/anonymization/processor/AnonymizedDatasetProcessor.java
+++ b/cinnamon-anonymization/src/main/java/de/kiaim/cinnamon/anonymization/processor/AnonymizedDatasetProcessor.java
@@ -185,6 +185,7 @@ public class AnonymizedDatasetProcessor {
                 case DECIMAL -> null;
                 case INTEGER -> null;
                 case STRING -> null;
+                case TEXT -> null;
                 default -> throw new IllegalArgumentException("Unknown data type: " + type);
             };
         }
@@ -197,6 +198,7 @@ public class AnonymizedDatasetProcessor {
                 case DECIMAL -> Float.parseFloat(value);
                 case INTEGER -> Integer.parseInt(value);
                 case STRING -> value;
+                case TEXT -> value;
                 default -> throw new IllegalArgumentException("Unknown data type: " + type);
             };
         } catch (Exception e) {

--- a/cinnamon-anonymization/src/main/java/de/kiaim/cinnamon/anonymization/service/CompatibilityAssurance.java
+++ b/cinnamon-anonymization/src/main/java/de/kiaim/cinnamon/anonymization/service/CompatibilityAssurance.java
@@ -100,6 +100,7 @@ public class CompatibilityAssurance {
             case BOOLEAN -> data instanceof BooleanData;
             case DATE -> data instanceof DateData;
             case DATE_TIME -> data instanceof DateTimeData;
+            case TEXT -> data instanceof TextData;
             default -> false;
         };
     }

--- a/cinnamon-anonymization/src/main/java/org.bihmi.jal/anon/DataTypeConverter.java
+++ b/cinnamon-anonymization/src/main/java/org.bihmi.jal/anon/DataTypeConverter.java
@@ -12,6 +12,7 @@ public class DataTypeConverter {
 //            // TODO : handle BOOLEAN and DATE_TIME, find a better solution
             case "BOOLEAN" -> DataType.STRING;
             case "DATE_TIME" -> DataType.DATE;
+            case "TEXT" -> DataType.STRING;
             default -> throw new IllegalArgumentException("String " + datatype + " could not be mapped to any ARX datatype.");
         };
     }

--- a/cinnamon-anonymization/src/test/java/de/kiaim/cinnamon/anonymization/processor/AnonymizedDatasetProcessorTest.java
+++ b/cinnamon-anonymization/src/test/java/de/kiaim/cinnamon/anonymization/processor/AnonymizedDatasetProcessorTest.java
@@ -1,15 +1,26 @@
 package de.kiaim.cinnamon.anonymization.processor;
 
 import de.kiaim.cinnamon.anonymization.AbstractAnonymizationTests;
+import de.kiaim.cinnamon.model.configuration.data.attributes.ColumnConfiguration;
+import de.kiaim.cinnamon.model.configuration.data.attributes.DataConfiguration;
+import de.kiaim.cinnamon.model.data.Data;
 import de.kiaim.cinnamon.model.data.DataSet;
+import de.kiaim.cinnamon.model.data.DecimalData;
+import de.kiaim.cinnamon.model.data.TextData;
+import de.kiaim.cinnamon.model.enumeration.DataScale;
+import de.kiaim.cinnamon.model.enumeration.DataType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import static de.kiaim.cinnamon.anonymization.processor.AnonymizedDatasetProcessor.containsStarWithOtherCharacters;
 import static de.kiaim.cinnamon.anonymization.service.CompatibilityAssurance.isDataSetCompatible;
@@ -69,6 +80,44 @@ public class AnonymizedDatasetProcessorTest extends AbstractAnonymizationTests {
         String value6 = "123*456";
         assertTrue(containsStarWithOtherCharacters(value6));
 
+    }
+
+    private static Stream<Arguments> conversionTestCases() {
+        String[][] nullSample = {{"note"}, {"null"}};
+        String[][] textSample = {{"note"}, {"Patient reports mild symptoms after treatment."}};
+        String[][] decimalSample = {{"weight"}, {"0.3"}};
+        return Stream.of(
+                Arguments.of(nullSample, DataType.TEXT, DataScale.NOMINAL, TextData.class, null),
+                Arguments.of(textSample, DataType.TEXT, DataScale.NOMINAL, TextData.class, textSample[1][0]),
+                Arguments.of(decimalSample, DataType.DECIMAL, DataScale.ORDINAL, DecimalData.class,
+                        Float.parseFloat(decimalSample[1][0]))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("conversionTestCases")
+    public void testConvertToDataSet(String[][] anonymizedData, DataType dataType,
+                                     DataScale dataScale, Class<?> cls, Object expected) {
+        DataConfiguration config = dataConfiguration(anonymizedData[0][0], dataType, dataScale);
+        DataSet result = AnonymizedDatasetProcessor.convertToDataSet(anonymizedData, config);
+
+        assertEquals(1, result.getDataRows().size());
+        Data data = result.getDataRows().get(0).getData().get(0);
+        assertInstanceOf(cls, data);
+        assertEquals(expected, data.getValue());
+        assertTrue(isDataSetCompatible(result));
+    }
+
+    private static DataConfiguration dataConfiguration(String name, DataType dataType,
+                                                           DataScale dataScale) {
+        DataConfiguration configuration = new DataConfiguration();
+        ColumnConfiguration column = new ColumnConfiguration();
+        column.setIndex(0);
+        column.setName(name);
+        column.setType(dataType);
+        column.setScale(dataScale);
+        configuration.addColumnConfiguration(column);
+        return configuration;
     }
 
 }

--- a/cinnamon-anonymization/src/test/java/org/bihmi/jal/anon/DataTypeConverterTest.java
+++ b/cinnamon-anonymization/src/test/java/org/bihmi/jal/anon/DataTypeConverterTest.java
@@ -1,0 +1,14 @@
+package org.bihmi.jal.anon;
+
+import org.deidentifier.arx.DataType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataTypeConverterTest {
+
+    @Test
+    void testDataTypeConverter() {
+        assertEquals(DataType.STRING, DataTypeConverter.get("TEXT"));
+    }
+}


### PR DESCRIPTION
Previously, we could not execute the anonymization step if there were "TEXT" columns in the csv file.
This is now handled and the anonymization step can be executed.